### PR TITLE
Spinel client with IO

### DIFF
--- a/ziggurat/Cargo.lock
+++ b/ziggurat/Cargo.lock
@@ -29,6 +29,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,6 +59,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -222,16 +281,16 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -264,6 +323,12 @@ dependencies = [
  "unicode-width",
  "vec_map",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "constant_time_eq"
@@ -367,6 +432,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "error-chain"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +529,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hybrid-array"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +581,12 @@ dependencies = [
  "block-padding",
  "hybrid-array",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -773,6 +873,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "rust-argon2"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1154,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1291,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1264,6 +1408,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-sys"
@@ -1441,17 +1591,22 @@ dependencies = [
  "aes",
  "cargo-debug",
  "cbc",
+ "chrono",
  "constant_time_eq 0.3.1",
  "crc_all",
  "derivative",
+ "env_logger",
  "hex",
  "hex-literal",
  "inline_colorization",
+ "log",
  "pcap-parser",
  "rand",
+ "serial2",
  "serial2-tokio",
  "shellexpand",
  "strum_macros",
+ "termios",
  "tokio",
  "tracing",
 ]

--- a/ziggurat/Cargo.toml
+++ b/ziggurat/Cargo.toml
@@ -19,6 +19,11 @@ strum_macros = "0.26.4"
 serial2-tokio = "0.1.14"
 tokio = { version = "1.43.0", features = ["full"] }
 tracing = "0.1.41"
+log = "0.4.26"
+env_logger = "0.11.6"
+chrono = "0.4.40"
+termios = "0.3.3"
+serial2 = "0.2.28"
 
 [[bin]]
 name = "ziggurat-pcap"

--- a/ziggurat/Cargo.toml
+++ b/ziggurat/Cargo.toml
@@ -28,6 +28,10 @@ path = "src/tools/dump_pcap.rs"
 name = "ziggurat-capture"
 path = "src/tools/packet_capture.rs"
 
+[[bin]]
+name = "ziggurat-sender"
+path = "src/tools/packet_sender.rs"
+
 [dev-dependencies]
 cargo-debug = "0.3.0"
 rand = "0.8.5"

--- a/ziggurat/src/lib.rs
+++ b/ziggurat/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod ieee_802154;
 pub mod spinel;
+pub mod spinel_client;
 pub mod types;
 pub mod zigbee_aps;
 pub mod zigbee_nwk;

--- a/ziggurat/src/spinel.rs
+++ b/ziggurat/src/spinel.rs
@@ -3,7 +3,7 @@
 use crc_all::CrcAlgo;
 use std::collections::HashMap;
 use strum_macros::FromRepr;
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc, oneshot};
 
 const CRC_KERMIT: CrcAlgo<u16> = CrcAlgo::<u16>::new(0x1021, 16, 0xFFFF, 0xFFFF, true);
 const U21_MAX: u32 = 1 << 21;
@@ -445,12 +445,39 @@ impl SpinelFrame {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct SpinelFramePropValueIs {
+    pub property_id: u32,
+    pub value: Vec<u8>,
+}
+
+impl SpinelFramePropValueIs {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
+        match packed_uint21_deserialize(bytes) {
+            Ok((property_id, remaining)) => Ok(Self {
+                property_id: property_id,
+                value: remaining.to_vec(),
+            }),
+            Err(err) => Err(err),
+        }
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut result = packed_uint21_to_bytes(self.property_id);
+        result.extend(self.value.iter());
+
+        result
+    }
+}
+
 #[derive(Debug)]
 pub struct SpinelProtocol {
     pub buffer: Vec<u8>,
     pub ignoring_until_next_flag: bool,
     pub next_tid: u8,
     pub pending_frames: HashMap<u8, oneshot::Sender<SpinelFrame>>,
+    pub unsolicited_frame_receiver: Option<mpsc::Sender<SpinelFrame>>,
+    pub property_update_receivers: HashMap<u32, mpsc::Sender<SpinelFramePropValueIs>>,
 }
 
 impl SpinelProtocol {
@@ -460,7 +487,21 @@ impl SpinelProtocol {
             ignoring_until_next_flag: true,
             next_tid: 1,
             pending_frames: HashMap::new(),
+            unsolicited_frame_receiver: None,
+            property_update_receivers: HashMap::new(),
         }
+    }
+
+    pub fn set_unsolicited_frame_receiver(&mut self, tx: mpsc::Sender<SpinelFrame>) {
+        self.unsolicited_frame_receiver = Some(tx);
+    }
+
+    pub fn set_property_update_receiver(
+        &mut self,
+        property_id: u32,
+        tx: mpsc::Sender<SpinelFramePropValueIs>,
+    ) {
+        self.property_update_receivers.insert(property_id, tx);
     }
 
     pub fn parse_frames_from_bytes_into(
@@ -519,8 +560,6 @@ impl SpinelProtocol {
 
     pub fn handle_inbound_bytes(&mut self, bytes: &[u8]) {
         for frame in self.parse_frames_from_bytes(bytes) {
-            eprintln!("Got frame {:?}", frame);
-
             self.handle_inbound_frame(frame);
         }
     }
@@ -528,7 +567,30 @@ impl SpinelProtocol {
     pub fn handle_inbound_frame(&mut self, frame: SpinelFrame) {
         let tid = frame.header.transaction_id;
 
-        if let Some(sender) = self.pending_frames.remove(&tid) {
+        if tid == 0 {
+            if frame.command_id == SpinelCommandId::PropValueIs as u8 {
+                match SpinelFramePropValueIs::from_bytes(&frame.payload) {
+                    Ok(prop_value_is) => {
+                        match self
+                            .property_update_receivers
+                            .get(&prop_value_is.property_id)
+                        {
+                            Some(sender) => {
+                                let _ = sender.try_send(prop_value_is);
+                            }
+                            None => {
+                                eprintln!("No receiver for property update: {:?}", prop_value_is);
+                            }
+                        }
+                    }
+                    Err(_) => {
+                        eprintln!("Failed to parse PropValueIs frame: {:?}", frame);
+                    }
+                }
+            } else {
+                eprintln!("Unhandled unsolicited frame: {:?}", frame);
+            }
+        } else if let Some(sender) = self.pending_frames.remove(&tid) {
             let _ = sender.send(frame);
         } else {
             eprintln!("Unsolicited or unmatched frame: {:?}", frame);
@@ -559,6 +621,8 @@ impl SpinelProtocol {
         // Create a one-shot channel for the response
         let (tx, rx) = oneshot::channel();
         self.pending_frames.insert(tid, tx);
+
+        eprintln!("Prepared frame {:?}", frame);
 
         (frame, rx)
     }

--- a/ziggurat/src/spinel.rs
+++ b/ziggurat/src/spinel.rs
@@ -218,11 +218,15 @@ pub enum SpinelStatus {
 pub fn packed_uint21_deserialize(bytes: &[u8]) -> Result<(u32, &[u8]), &'static str> {
     let mut result = 0u32;
 
-    for (index, byte) in bytes[..3].iter().enumerate() {
+    for (index, byte) in bytes.iter().enumerate() {
         result |= ((byte & 0b01111111) as u32) << (7 * index);
 
         if byte & 0b10000000 == 0 {
             return Ok((result, &bytes[index + 1..]));
+        }
+
+        if index >= 2 {
+            break;
         }
     }
 
@@ -352,6 +356,16 @@ impl HdlcLiteFrame {
                 result.push(result_byte);
             }
         }
+
+        result
+    }
+
+    pub fn to_bytes_with_flags(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+
+        result.push(HdlcSpecial::Flag as u8);
+        result.extend(self.to_bytes());
+        result.push(HdlcSpecial::Flag as u8);
 
         result
     }

--- a/ziggurat/src/spinel.rs
+++ b/ziggurat/src/spinel.rs
@@ -1,6 +1,9 @@
 #![allow(dead_code)]
 
 use crc_all::CrcAlgo;
+use env_logger::Builder;
+use log;
+use log::LevelFilter;
 use std::collections::HashMap;
 use strum_macros::FromRepr;
 use tokio::sync::{mpsc, oneshot};
@@ -559,13 +562,15 @@ impl SpinelProtocol {
     }
 
     pub fn handle_inbound_bytes(&mut self, bytes: &[u8]) {
+        log::debug!("RX bytes: {bytes:?}");
+
         for frame in self.parse_frames_from_bytes(bytes) {
             self.handle_inbound_frame(frame);
         }
     }
 
     pub fn handle_inbound_frame(&mut self, frame: SpinelFrame) {
-        eprintln!("Received frame {:?}", frame);
+        log::debug!("RX: {frame:?}");
         let tid = frame.header.transaction_id;
 
         if tid == 0 {
@@ -622,8 +627,6 @@ impl SpinelProtocol {
         // Create a one-shot channel for the response
         let (tx, rx) = oneshot::channel();
         self.pending_frames.insert(tid, tx);
-
-        eprintln!("Prepared frame {:?}", frame);
 
         (frame, rx)
     }

--- a/ziggurat/src/spinel.rs
+++ b/ziggurat/src/spinel.rs
@@ -565,6 +565,7 @@ impl SpinelProtocol {
     }
 
     pub fn handle_inbound_frame(&mut self, frame: SpinelFrame) {
+        eprintln!("Received frame {:?}", frame);
         let tid = frame.header.transaction_id;
 
         if tid == 0 {

--- a/ziggurat/src/spinel_client.rs
+++ b/ziggurat/src/spinel_client.rs
@@ -9,36 +9,40 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::time::{timeout, Duration};
 
-const TIMEOUT: Duration = Duration::from_secs(5);
+const TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct SpinelTxFrame {
     pub psdu: Vec<u8>,
     pub channel: u8,
-    pub cca_backoff_attempts: u8,
-    pub cca_retries: u8,
+    pub max_csma_backoffs: u8,
+    pub max_frame_retries: u8,
+    pub enable_csma_ca: bool,
     pub is_header_updated: bool,
     pub is_a_retransmit: bool,
     pub is_security_processed: bool,
     pub tx_delay: u32,
     pub tx_delay_base_time: u32,
     pub rx_channel_after_tx: u8,
+    pub tx_power: i8,
 }
 
 impl SpinelTxFrame {
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut result = Vec::new();
-        result.extend_from_slice(&self.psdu.len().to_le_bytes());
+        result.extend_from_slice(&(self.psdu.len() as u16).to_le_bytes());
         result.extend_from_slice(&self.psdu);
         result.push(self.channel);
-        result.push(self.cca_backoff_attempts);
-        result.push(self.cca_retries);
+        result.push(self.max_csma_backoffs);
+        result.push(self.max_frame_retries);
+        result.push(self.enable_csma_ca as u8);
         result.push(self.is_header_updated as u8);
         result.push(self.is_a_retransmit as u8);
         result.push(self.is_security_processed as u8);
         result.extend_from_slice(&self.tx_delay.to_le_bytes());
         result.extend_from_slice(&self.tx_delay_base_time.to_le_bytes());
-        result.push(self.rx_channel_after_tx as u8);
+        result.push(self.rx_channel_after_tx);
+        result.push(self.tx_power as u8);
 
         result
     }
@@ -277,11 +281,14 @@ impl SpinelClient {
             .to_string())
     }
 
-    pub async fn transmit_frame(&self, tx_frame: SpinelTxFrame) -> Result<u8, SpinelSendError> {
+    pub async fn transmit_frame(&self, tx_frame: &SpinelTxFrame) -> Result<u8, SpinelSendError> {
         let (rsp_prop_id, rsp) = self
             .prop_value_set(SpinelPropertyId::StreamRaw as u32, tx_frame.to_bytes())
             .await
             .unwrap();
+
+        Ok(1)
+        /*
 
         if rsp_prop_id != SpinelPropertyId::LastStatus as u32 {
             return Err(SpinelSendError::IoError(std::io::Error::new(
@@ -299,5 +306,6 @@ impl SpinelClient {
 
         let status = rsp[0];
         Ok(status)
+        */
     }
 }

--- a/ziggurat/src/spinel_client.rs
+++ b/ziggurat/src/spinel_client.rs
@@ -1,17 +1,20 @@
 use crate::spinel::{
-    packed_uint21_deserialize, packed_uint21_to_bytes, HdlcLiteFrame, HdlcSpecial, SpinelCommandId,
-    SpinelFrame, SpinelProtocol, SpinelResetReason,
+    packed_uint21_deserialize, packed_uint21_to_bytes, HdlcLiteFrame, SpinelCommandId, SpinelFrame,
+    SpinelPropertyId, SpinelProtocol,
 };
 use serial2_tokio::SerialPort;
+use std::string::String;
+
 use std::sync::Arc;
-use tokio::sync::oneshot;
 use tokio::sync::Mutex;
 use tokio::time::{timeout, Duration};
 
+const TIMEOUT: Duration = Duration::from_secs(5);
+
 #[derive(Clone)]
 pub struct SpinelClient {
-    port: Arc<SerialPort>,
-    protocol: Arc<Mutex<SpinelProtocol>>,
+    pub port: Arc<SerialPort>,
+    pub protocol: Arc<Mutex<SpinelProtocol>>,
 }
 
 #[derive(Debug)]
@@ -40,8 +43,6 @@ impl SpinelClient {
             loop {
                 match port_clone.read(&mut buffer).await {
                     Ok(n) if n > 0 => {
-                        eprintln!("Read {} bytes: {:?}", n, &buffer[..n]);
-
                         let mut protocol = client_clone.lock().await;
                         protocol.handle_inbound_bytes(&buffer[..n])
                     }
@@ -58,11 +59,10 @@ impl SpinelClient {
         });
     }
 
-    pub async fn send_command_with_timeout(
+    pub async fn send_command(
         &self,
         command_id: u8,
         payload: Vec<u8>,
-        timeout_duration: Duration,
     ) -> Result<SpinelFrame, SpinelSendError> {
         let (frame, rx) = {
             let mut guard = self.protocol.lock().await;
@@ -74,14 +74,13 @@ impl SpinelClient {
         };
 
         let data = hdlc_frame.to_bytes_with_flags();
-        eprintln!("Sending: {:?}", data);
 
         self.port
             .write(&data)
             .await
             .map_err(SpinelSendError::IoError)?;
 
-        match timeout(timeout_duration, rx).await {
+        match timeout(TIMEOUT, rx).await {
             Ok(Ok(response_frame)) => Ok(response_frame),
             Ok(Err(_recv_closed)) => {
                 let mut guard = self.protocol.lock().await;
@@ -98,16 +97,11 @@ impl SpinelClient {
         }
     }
 
-    pub async fn prop_value_get(
-        &self,
-        property_id: u32,
-        timeout_duration: Duration,
-    ) -> Result<Vec<u8>, SpinelSendError> {
+    pub async fn prop_value_get(&self, property_id: u32) -> Result<Vec<u8>, SpinelSendError> {
         let response = self
-            .send_command_with_timeout(
+            .send_command(
                 SpinelCommandId::PropValueGet as u8,
                 packed_uint21_to_bytes(property_id),
-                timeout_duration,
             )
             .await?;
 
@@ -136,17 +130,15 @@ impl SpinelClient {
         &self,
         property_id: u32,
         value: Vec<u8>,
-        timeout_duration: Duration,
     ) -> Result<Vec<u8>, SpinelSendError> {
         let response = self
-            .send_command_with_timeout(
+            .send_command(
                 SpinelCommandId::PropValueSet as u8,
                 packed_uint21_to_bytes(property_id)
                     .iter()
                     .chain(value.iter())
                     .cloned()
                     .collect(),
-                timeout_duration,
             )
             .await?;
 
@@ -169,5 +161,19 @@ impl SpinelClient {
         }
 
         Ok(payload.to_vec())
+    }
+
+    pub async fn get_ncp_version(&self) -> Result<String, SpinelSendError> {
+        let ncp_version_rsp = self
+            .prop_value_get(SpinelPropertyId::NcpVersion as u32)
+            .await
+            .unwrap();
+
+        let ncp_version_with_null =
+            String::from_utf8(ncp_version_rsp).expect("Invalid UTF-8 string");
+
+        Ok(ncp_version_with_null
+            .trim_matches(char::from(0x00))
+            .to_string())
     }
 }

--- a/ziggurat/src/spinel_client.rs
+++ b/ziggurat/src/spinel_client.rs
@@ -186,12 +186,15 @@ impl SpinelClient {
             guard.prepare_request(command_id, payload)
         };
 
+        log::debug!("Sending frame {:?}", frame);
+
         let hdlc_frame = HdlcLiteFrame {
             data: frame.to_bytes(),
         };
 
         let data = hdlc_frame.to_bytes_with_flags();
 
+        log::debug!("Writing {:02X?}", data);
         self.port
             .write(&data)
             .await
@@ -262,6 +265,14 @@ impl SpinelClient {
                 )))
             }
         };
+
+        log::info!(
+            "Setting property {}={:02X?}, result {}={:02X?}",
+            property_id,
+            value,
+            rsp_property_id,
+            payload
+        );
 
         Ok((rsp_property_id, payload.to_vec()))
     }

--- a/ziggurat/src/spinel_client.rs
+++ b/ziggurat/src/spinel_client.rs
@@ -1,6 +1,6 @@
 use crate::spinel::{
     packed_uint21_deserialize, packed_uint21_to_bytes, HdlcLiteFrame, SpinelCommandId, SpinelFrame,
-    SpinelPropertyId, SpinelProtocol,
+    SpinelPropertyId, SpinelProtocol, SpinelStatus,
 };
 use serial2_tokio::SerialPort;
 use std::string::String;
@@ -10,6 +10,119 @@ use tokio::sync::Mutex;
 use tokio::time::{timeout, Duration};
 
 const TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct SpinelTxFrame {
+    pub psdu: Vec<u8>,
+    pub channel: u8,
+    pub cca_backoff_attempts: u8,
+    pub cca_retries: u8,
+    pub is_header_updated: bool,
+    pub is_a_retransmit: bool,
+    pub is_security_processed: bool,
+    pub tx_delay: u32,
+    pub tx_delay_base_time: u32,
+    pub rx_channel_after_tx: u8,
+}
+
+impl SpinelTxFrame {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        result.extend_from_slice(&self.psdu.len().to_le_bytes());
+        result.extend_from_slice(&self.psdu);
+        result.push(self.channel);
+        result.push(self.cca_backoff_attempts);
+        result.push(self.cca_retries);
+        result.push(self.is_header_updated as u8);
+        result.push(self.is_a_retransmit as u8);
+        result.push(self.is_security_processed as u8);
+        result.extend_from_slice(&self.tx_delay.to_le_bytes());
+        result.extend_from_slice(&self.tx_delay_base_time.to_le_bytes());
+        result.push(self.rx_channel_after_tx as u8);
+
+        result
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct SpinelRxFrame {
+    pub psdu: Vec<u8>,
+    pub rssi: i8,
+    pub noise_floor: i8,
+    pub flags: u32,
+    pub channel: u8,
+    pub lqi: u8,
+    pub timestamp_us: u64,
+    pub receive_error: u8,
+    pub manufacturer_specific: Vec<u8>,
+}
+
+impl SpinelRxFrame {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
+        eprintln!("bytes: {:02x?}", bytes);
+
+        let mut offset = 0;
+
+        let psdu_len = u16::from_le_bytes([bytes[offset], bytes[offset + 1]]) as usize;
+        offset += 2;
+
+        if offset + (psdu_len + 1 + 1 + 4 + 1 + 1 + 8 + 1) > bytes.len() {
+            return Err("Invalid frame length");
+        }
+
+        let psdu = bytes[offset..offset + psdu_len].to_vec();
+        offset += psdu_len;
+
+        let rssi = bytes[offset] as i8;
+        offset += 1;
+
+        let noise_floor = bytes[offset] as i8;
+        offset += 1;
+
+        let flags = u32::from_le_bytes([
+            bytes[offset],
+            bytes[offset + 1],
+            bytes[offset + 2],
+            bytes[offset + 3],
+        ]);
+        offset += 4;
+
+        let channel = bytes[offset];
+        offset += 1;
+
+        let lqi = bytes[offset];
+        offset += 1;
+
+        let timestamp_us = u64::from_le_bytes([
+            bytes[offset],
+            bytes[offset + 1],
+            bytes[offset + 2],
+            bytes[offset + 3],
+            bytes[offset + 4],
+            bytes[offset + 5],
+            bytes[offset + 6],
+            bytes[offset + 7],
+        ]);
+        offset += 8;
+
+        let receive_error = bytes[offset];
+        offset += 1;
+
+        let manufacturer_specific = bytes[offset..].to_vec();
+
+        Ok(Self {
+            psdu,
+            rssi,
+            noise_floor,
+            flags,
+            channel,
+            lqi,
+            timestamp_us,
+            receive_error,
+            manufacturer_specific,
+        })
+    }
+}
 
 #[derive(Clone)]
 pub struct SpinelClient {
@@ -106,7 +219,7 @@ impl SpinelClient {
             .await?;
 
         let response_payload = response.payload;
-        let (rsp_property_id, payload) = match packed_uint21_deserialize(&response_payload) {
+        let (_rsp_property_id, payload) = match packed_uint21_deserialize(&response_payload) {
             Ok((property_id, payload)) => (property_id, payload),
             Err(e) => {
                 return Err(SpinelSendError::IoError(std::io::Error::new(
@@ -116,13 +229,6 @@ impl SpinelClient {
             }
         };
 
-        if rsp_property_id != property_id {
-            return Err(SpinelSendError::IoError(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "Property ID mismatch",
-            )));
-        }
-
         Ok(payload.to_vec())
     }
 
@@ -130,7 +236,7 @@ impl SpinelClient {
         &self,
         property_id: u32,
         value: Vec<u8>,
-    ) -> Result<Vec<u8>, SpinelSendError> {
+    ) -> Result<(u32, Vec<u8>), SpinelSendError> {
         let response = self
             .send_command(
                 SpinelCommandId::PropValueSet as u8,
@@ -153,16 +259,10 @@ impl SpinelClient {
             }
         };
 
-        if rsp_property_id != property_id {
-            return Err(SpinelSendError::IoError(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "Property ID mismatch",
-            )));
-        }
-
-        Ok(payload.to_vec())
+        Ok((rsp_property_id, payload.to_vec()))
     }
 
+    // Convenience method wrapping broad functionality are below
     pub async fn get_ncp_version(&self) -> Result<String, SpinelSendError> {
         let ncp_version_rsp = self
             .prop_value_get(SpinelPropertyId::NcpVersion as u32)
@@ -175,5 +275,29 @@ impl SpinelClient {
         Ok(ncp_version_with_null
             .trim_matches(char::from(0x00))
             .to_string())
+    }
+
+    pub async fn transmit_frame(&self, tx_frame: SpinelTxFrame) -> Result<u8, SpinelSendError> {
+        let (rsp_prop_id, rsp) = self
+            .prop_value_set(SpinelPropertyId::StreamRaw as u32, tx_frame.to_bytes())
+            .await
+            .unwrap();
+
+        if rsp_prop_id != SpinelPropertyId::LastStatus as u32 {
+            return Err(SpinelSendError::IoError(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Unexpected response property ID",
+            )));
+        }
+
+        if rsp.len() < 1 {
+            return Err(SpinelSendError::IoError(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Unexpected response length",
+            )));
+        }
+
+        let status = rsp[0];
+        Ok(status)
     }
 }

--- a/ziggurat/src/spinel_client.rs
+++ b/ziggurat/src/spinel_client.rs
@@ -1,0 +1,173 @@
+use crate::spinel::{
+    packed_uint21_deserialize, packed_uint21_to_bytes, HdlcLiteFrame, HdlcSpecial, SpinelCommandId,
+    SpinelFrame, SpinelProtocol, SpinelResetReason,
+};
+use serial2_tokio::SerialPort;
+use std::sync::Arc;
+use tokio::sync::oneshot;
+use tokio::sync::Mutex;
+use tokio::time::{timeout, Duration};
+
+#[derive(Clone)]
+pub struct SpinelClient {
+    port: Arc<SerialPort>,
+    protocol: Arc<Mutex<SpinelProtocol>>,
+}
+
+#[derive(Debug)]
+pub enum SpinelSendError {
+    IoError(std::io::Error),
+    ChannelClosed,
+    Timeout,
+}
+
+impl SpinelClient {
+    pub fn new(port: SerialPort) -> Self {
+        Self {
+            port: Arc::new(port),
+            protocol: Arc::new(Mutex::new(SpinelProtocol::new())),
+        }
+    }
+
+    /// Start a reading loop to parse and handle inbound frames.
+    pub fn spawn_reader(&self) {
+        let port_clone = Arc::clone(&self.port);
+        let client_clone = Arc::clone(&self.protocol);
+
+        tokio::spawn(async move {
+            let mut buffer = [0u8; 2048];
+
+            loop {
+                match port_clone.read(&mut buffer).await {
+                    Ok(n) if n > 0 => {
+                        eprintln!("Read {} bytes: {:?}", n, &buffer[..n]);
+
+                        let mut protocol = client_clone.lock().await;
+                        protocol.handle_inbound_bytes(&buffer[..n])
+                    }
+                    Ok(_) => {
+                        eprintln!("EOF or 0 bytes read, stopping.");
+                        break;
+                    }
+                    Err(e) => {
+                        eprintln!("Error reading port: {:?}", e);
+                        break;
+                    }
+                }
+            }
+        });
+    }
+
+    pub async fn send_command_with_timeout(
+        &self,
+        command_id: u8,
+        payload: Vec<u8>,
+        timeout_duration: Duration,
+    ) -> Result<SpinelFrame, SpinelSendError> {
+        let (frame, rx) = {
+            let mut guard = self.protocol.lock().await;
+            guard.prepare_request(command_id, payload)
+        };
+
+        let hdlc_frame = HdlcLiteFrame {
+            data: frame.to_bytes(),
+        };
+
+        let data = hdlc_frame.to_bytes_with_flags();
+        eprintln!("Sending: {:?}", data);
+
+        self.port
+            .write(&data)
+            .await
+            .map_err(SpinelSendError::IoError)?;
+
+        match timeout(timeout_duration, rx).await {
+            Ok(Ok(response_frame)) => Ok(response_frame),
+            Ok(Err(_recv_closed)) => {
+                let mut guard = self.protocol.lock().await;
+                guard.cancel_request(frame.header.transaction_id);
+
+                Err(SpinelSendError::ChannelClosed)
+            }
+            Err(_elapsed) => {
+                let mut guard = self.protocol.lock().await;
+                guard.cancel_request(frame.header.transaction_id);
+
+                Err(SpinelSendError::Timeout)
+            }
+        }
+    }
+
+    pub async fn prop_value_get(
+        &self,
+        property_id: u32,
+        timeout_duration: Duration,
+    ) -> Result<Vec<u8>, SpinelSendError> {
+        let response = self
+            .send_command_with_timeout(
+                SpinelCommandId::PropValueGet as u8,
+                packed_uint21_to_bytes(property_id),
+                timeout_duration,
+            )
+            .await?;
+
+        let response_payload = response.payload;
+        let (rsp_property_id, payload) = match packed_uint21_deserialize(&response_payload) {
+            Ok((property_id, payload)) => (property_id, payload),
+            Err(e) => {
+                return Err(SpinelSendError::IoError(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    e,
+                )))
+            }
+        };
+
+        if rsp_property_id != property_id {
+            return Err(SpinelSendError::IoError(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Property ID mismatch",
+            )));
+        }
+
+        Ok(payload.to_vec())
+    }
+
+    pub async fn prop_value_set(
+        &self,
+        property_id: u32,
+        value: Vec<u8>,
+        timeout_duration: Duration,
+    ) -> Result<Vec<u8>, SpinelSendError> {
+        let response = self
+            .send_command_with_timeout(
+                SpinelCommandId::PropValueSet as u8,
+                packed_uint21_to_bytes(property_id)
+                    .iter()
+                    .chain(value.iter())
+                    .cloned()
+                    .collect(),
+                timeout_duration,
+            )
+            .await?;
+
+        let response_payload = response.payload;
+        let (rsp_property_id, payload) = match packed_uint21_deserialize(&response_payload) {
+            Ok((property_id, payload)) => (property_id, payload),
+            Err(e) => {
+                return Err(SpinelSendError::IoError(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    e,
+                )))
+            }
+        };
+
+        if rsp_property_id != property_id {
+            return Err(SpinelSendError::IoError(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Property ID mismatch",
+            )));
+        }
+
+        Ok(payload.to_vec())
+    }
+}

--- a/ziggurat/src/tools/packet_capture.rs
+++ b/ziggurat/src/tools/packet_capture.rs
@@ -1,16 +1,9 @@
 use serial2_tokio::SerialPort;
-use ziggurat::spinel::{
-    packed_uint21_to_bytes, HdlcLiteFrame, SpinelCommandId, SpinelFrame, SpinelHeader,
-    SpinelPropertyId, SpinelProtocol, SpinelResetReason,
-};
+use ziggurat::ieee_802154::Ieee802154Frame;
+use ziggurat::spinel::SpinelPropertyId;
 use ziggurat::spinel_client::SpinelClient;
 
-use std::string::String;
-
-use std::collections::HashMap;
-use std::sync::Arc;
-use tokio::sync::{mpsc, oneshot, Mutex};
-use tokio::task;
+use tokio::sync::mpsc;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -19,47 +12,59 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = SpinelClient::new(port);
     client.spawn_reader();
 
-    let timeout = std::time::Duration::from_secs(5);
-    let ncp_version_rsp = client
-        .prop_value_get(SpinelPropertyId::NcpVersion as u32, timeout)
+    let ncp_version = client
+        .get_ncp_version()
         .await
-        .unwrap();
-
-    let ncp_version_with_null = String::from_utf8(ncp_version_rsp).expect("Invalid UTF-8 string");
-    let ncp_version = ncp_version_with_null.trim_matches(char::from(0x00));
-
+        .expect("Invalid UTF-8 string");
     println!("NCP Version: {:?}", ncp_version);
 
     client
-        .prop_value_set(SpinelPropertyId::PhyEnabled as u32, vec![1], timeout)
+        .prop_value_set(SpinelPropertyId::PhyEnabled as u32, vec![true as u8])
         .await
-        .unwrap();
+        .expect("Failed to enable the PHY");
 
     client
-        .prop_value_set(
-            SpinelPropertyId::MacPromiscuousMode as u32,
-            vec![2],
-            timeout,
-        )
+        .prop_value_set(SpinelPropertyId::MacPromiscuousMode as u32, vec![2])
         .await
-        .unwrap();
+        .expect("Failed to set the MAC promiscuous mode");
+
+    client
+        .prop_value_set(SpinelPropertyId::PhyChan as u32, vec![25])
+        .await
+        .expect("Failed to set the PHY");
 
     client
         .prop_value_set(
             SpinelPropertyId::MacRawStreamEnabled as u32,
-            vec![1],
-            timeout,
+            vec![true as u8],
         )
         .await
-        .unwrap();
+        .expect("Failed to enable the RAW stream");
 
-    client
-        .prop_value_set(SpinelPropertyId::PhyChan as u32, vec![25], timeout)
-        .await
-        .unwrap();
+    let (stream_raw_tx, mut stream_raw_rx) = mpsc::channel(32);
 
-    // Sleep for 30s
-    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+    {
+        let mut guard = client.protocol.lock().await;
+        guard.set_property_update_receiver(SpinelPropertyId::StreamRaw as u32, stream_raw_tx);
+    }
+
+    while let Some(stream_raw_prop) = stream_raw_rx.recv().await {
+        let raw_packet = stream_raw_prop.value;
+        if raw_packet.len() < 2 {
+            continue;
+        }
+
+        let packet_len = u16::from_le_bytes([raw_packet[0], raw_packet[1]]) as usize;
+        if packet_len > raw_packet.len() - 2 {
+            continue;
+        }
+
+        let frame_data = raw_packet[2..packet_len + 2].to_vec();
+
+        if let Ok(ieee_frame) = Ieee802154Frame::from_bytes_without_fcs(&frame_data) {
+            println!("Received frame: {:#?}\n\n", ieee_frame);
+        }
+    }
 
     Ok(())
 }

--- a/ziggurat/src/tools/packet_capture.rs
+++ b/ziggurat/src/tools/packet_capture.rs
@@ -1,4 +1,5 @@
 use serial2_tokio::SerialPort;
+use std::env;
 use ziggurat::ieee_802154::Ieee802154Frame;
 use ziggurat::spinel::SpinelPropertyId;
 use ziggurat::spinel_client::{SpinelClient, SpinelRxFrame};
@@ -7,7 +8,8 @@ use tokio::sync::mpsc;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let port = SerialPort::open("/dev/cu.SLAB_USBtoUART", 460_800)?;
+    let args: Vec<String> = env::args().collect();
+    let port = SerialPort::open(&args[1], 460_800)?;
 
     let client = SpinelClient::new(port);
     client.spawn_reader();

--- a/ziggurat/src/tools/packet_capture.rs
+++ b/ziggurat/src/tools/packet_capture.rs
@@ -1,0 +1,65 @@
+use serial2_tokio::SerialPort;
+use ziggurat::spinel::{
+    packed_uint21_to_bytes, HdlcLiteFrame, SpinelCommandId, SpinelFrame, SpinelHeader,
+    SpinelPropertyId, SpinelProtocol, SpinelResetReason,
+};
+use ziggurat::spinel_client::SpinelClient;
+
+use std::string::String;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::task;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let port = SerialPort::open("/dev/cu.SLAB_USBtoUART", 460_800)?;
+
+    let client = SpinelClient::new(port);
+    client.spawn_reader();
+
+    let timeout = std::time::Duration::from_secs(5);
+    let ncp_version_rsp = client
+        .prop_value_get(SpinelPropertyId::NcpVersion as u32, timeout)
+        .await
+        .unwrap();
+
+    let ncp_version_with_null = String::from_utf8(ncp_version_rsp).expect("Invalid UTF-8 string");
+    let ncp_version = ncp_version_with_null.trim_matches(char::from(0x00));
+
+    println!("NCP Version: {:?}", ncp_version);
+
+    client
+        .prop_value_set(SpinelPropertyId::PhyEnabled as u32, vec![1], timeout)
+        .await
+        .unwrap();
+
+    client
+        .prop_value_set(
+            SpinelPropertyId::MacPromiscuousMode as u32,
+            vec![2],
+            timeout,
+        )
+        .await
+        .unwrap();
+
+    client
+        .prop_value_set(
+            SpinelPropertyId::MacRawStreamEnabled as u32,
+            vec![1],
+            timeout,
+        )
+        .await
+        .unwrap();
+
+    client
+        .prop_value_set(SpinelPropertyId::PhyChan as u32, vec![25], timeout)
+        .await
+        .unwrap();
+
+    // Sleep for 30s
+    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+
+    Ok(())
+}

--- a/ziggurat/src/tools/packet_capture.rs
+++ b/ziggurat/src/tools/packet_capture.rs
@@ -1,7 +1,7 @@
 use serial2_tokio::SerialPort;
 use ziggurat::ieee_802154::Ieee802154Frame;
 use ziggurat::spinel::SpinelPropertyId;
-use ziggurat::spinel_client::SpinelClient;
+use ziggurat::spinel_client::{SpinelClient, SpinelRxFrame};
 
 use tokio::sync::mpsc;
 
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("Failed to set the MAC promiscuous mode");
 
     client
-        .prop_value_set(SpinelPropertyId::PhyChan as u32, vec![25])
+        .prop_value_set(SpinelPropertyId::PhyChan as u32, vec![20])
         .await
         .expect("Failed to set the PHY");
 
@@ -48,21 +48,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         guard.set_property_update_receiver(SpinelPropertyId::StreamRaw as u32, stream_raw_tx);
     }
 
+    println!("Listening for packets...");
+
     while let Some(stream_raw_prop) = stream_raw_rx.recv().await {
         let raw_packet = stream_raw_prop.value;
-        if raw_packet.len() < 2 {
-            continue;
-        }
+        let packet = match SpinelRxFrame::from_bytes(&raw_packet) {
+            Ok(packet) => packet,
+            Err(e) => {
+                eprintln!("Error parsing packet: {:?}", e);
+                continue;
+            }
+        };
 
-        let packet_len = u16::from_le_bytes([raw_packet[0], raw_packet[1]]) as usize;
-        if packet_len > raw_packet.len() - 2 {
-            continue;
-        }
-
-        let frame_data = raw_packet[2..packet_len + 2].to_vec();
-
-        if let Ok(ieee_frame) = Ieee802154Frame::from_bytes_without_fcs(&frame_data) {
-            println!("Received frame: {:#?}\n\n", ieee_frame);
+        if let Ok(ieee_frame) = Ieee802154Frame::from_bytes_without_fcs(&packet.psdu) {
+            println!("Received packet {:#?}: {:#?}\n\n", packet, ieee_frame);
         }
     }
 

--- a/ziggurat/src/tools/packet_sender.rs
+++ b/ziggurat/src/tools/packet_sender.rs
@@ -1,0 +1,90 @@
+use serial2_tokio::SerialPort;
+use std::env;
+use ziggurat::ieee_802154::Ieee802154Frame;
+use ziggurat::spinel::SpinelPropertyId;
+use ziggurat::spinel_client::{SpinelClient, SpinelTxFrame};
+
+use tokio::sync::mpsc;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    let port = SerialPort::open(&args[1], 460_800)?;
+
+    let client = SpinelClient::new(port);
+    client.spawn_reader();
+
+    let ncp_version = client
+        .get_ncp_version()
+        .await
+        .expect("Invalid UTF-8 string");
+    println!("NCP Version: {:?}", ncp_version);
+
+    client
+        .prop_value_set(SpinelPropertyId::PhyEnabled as u32, vec![true as u8])
+        .await
+        .expect("Failed to enable the PHY");
+
+    client
+        .prop_value_set(SpinelPropertyId::MacPromiscuousMode as u32, vec![2])
+        .await
+        .expect("Failed to set the MAC promiscuous mode");
+
+    client
+        .prop_value_set(SpinelPropertyId::PhyChan as u32, vec![20])
+        .await
+        .expect("Failed to set the PHY");
+
+    client
+        .prop_value_set(
+            SpinelPropertyId::MacRawStreamEnabled as u32,
+            vec![true as u8],
+        )
+        .await
+        .expect("Failed to enable the RAW stream");
+
+    loop {
+        let frame = SpinelTxFrame {
+            psdu: Ieee802154Frame {
+                frame_control: Ieee802154FrameControl {
+                    frame_type: Command,
+                    security_enabled: false,
+                    frame_pending: false,
+                    ack_request: false,
+                    pan_id_compression: false,
+                    reserved: false,
+                    sequence_number_suppression: false,
+                    information_elements_present: false,
+                    dest_addr_mode: Short,
+                    frame_version: 0,
+                    src_addr_mode: None,
+                },
+                sequence_number: Some(164),
+                dest_pan_id: Some(PanId(0xffff)),
+                dest_address: Some(Nwk(Nwk(0xffff))),
+                src_pan_id: None,
+                src_address: None,
+                payload: b"\x07\x00\x09".to_vec(),
+                fcs: 12972,
+            },
+            channel: 20,
+            max_csma_backoffs: 1,
+            max_frame_retries: 4,
+            enable_csma_ca: true,
+            is_header_updated: true,
+            is_a_retransmit: false,
+            is_security_processed: true,
+            tx_delay: 0 as u32,
+            tx_delay_base_time: 0 as u32,
+            rx_channel_after_tx: 20,
+            tx_power: 8,
+        };
+
+        match client.transmit_frame(&frame).await {
+            Ok(status) => println!("Frame transmitted: {:?}", status),
+            Err(e) => eprintln!("Error transmitting frame: {:?}", e),
+        }
+    }
+
+    Ok(())
+}

--- a/ziggurat/src/tools/packet_sender.rs
+++ b/ziggurat/src/tools/packet_sender.rs
@@ -1,39 +1,52 @@
+use chrono::{DateTime, Local, TimeZone};
+use env_logger::builder;
+use log::LevelFilter;
+use serial2::Settings;
+use serial2::{FlowControl, IntoSettings};
 use serial2_tokio::SerialPort;
 use std::env;
+use std::io::Write;
+use tokio::sync::mpsc;
 use ziggurat::ieee_802154::Ieee802154Frame;
+use ziggurat::ieee_802154::{
+    Ieee802154Address, Ieee802154AddressingMode, Ieee802154FrameControl, Ieee802154FrameType,
+};
 use ziggurat::spinel::SpinelPropertyId;
 use ziggurat::spinel_client::{SpinelClient, SpinelTxFrame};
-
-use tokio::sync::mpsc;
+use ziggurat::types::{Nwk, PanId};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::builder()
+        .format_timestamp_micros()
+        .filter(None, LevelFilter::Debug)
+        .init();
+
     let args: Vec<String> = env::args().collect();
-    let port = SerialPort::open(&args[1], 460_800)?;
+    let port = SerialPort::open(&args[1], |mut settings: Settings| {
+        settings.set_raw();
+        settings.set_baud_rate(460_800)?;
+        Ok(settings)
+    })?;
 
     let client = SpinelClient::new(port);
     client.spawn_reader();
+    {
+        let mut protocol = client.protocol.lock().await;
+        protocol.next_tid = 3;
+    }
 
     let ncp_version = client
         .get_ncp_version()
         .await
         .expect("Invalid UTF-8 string");
+
     println!("NCP Version: {:?}", ncp_version);
 
     client
         .prop_value_set(SpinelPropertyId::PhyEnabled as u32, vec![true as u8])
         .await
         .expect("Failed to enable the PHY");
-
-    client
-        .prop_value_set(SpinelPropertyId::MacPromiscuousMode as u32, vec![2])
-        .await
-        .expect("Failed to set the MAC promiscuous mode");
-
-    client
-        .prop_value_set(SpinelPropertyId::PhyChan as u32, vec![20])
-        .await
-        .expect("Failed to set the PHY");
 
     client
         .prop_value_set(
@@ -43,11 +56,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await
         .expect("Failed to enable the RAW stream");
 
+    let channel = 19;
+    client
+        .prop_value_set(SpinelPropertyId::PhyChan as u32, vec![channel])
+        .await
+        .expect("Failed to set the PHY");
+
+    let mut last_time = std::time::Instant::now();
+
+    let mut sequence = 1;
+
     loop {
+        let mut now = std::time::Instant::now();
+        // Print time since last packet with 8 decimal places
+        println!(
+            "=== Delta {:0.8}",
+            now.duration_since(last_time).as_secs_f64()
+        );
+        last_time = now;
+
         let frame = SpinelTxFrame {
             psdu: Ieee802154Frame {
                 frame_control: Ieee802154FrameControl {
-                    frame_type: Command,
+                    frame_type: Ieee802154FrameType::Command,
                     security_enabled: false,
                     frame_pending: false,
                     ack_request: false,
@@ -55,19 +86,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     reserved: false,
                     sequence_number_suppression: false,
                     information_elements_present: false,
-                    dest_addr_mode: Short,
+                    dest_addr_mode: Ieee802154AddressingMode::Short,
                     frame_version: 0,
-                    src_addr_mode: None,
+                    src_addr_mode: Ieee802154AddressingMode::None,
                 },
-                sequence_number: Some(164),
+                sequence_number: Some(sequence),
                 dest_pan_id: Some(PanId(0xffff)),
-                dest_address: Some(Nwk(Nwk(0xffff))),
+                dest_address: Some(Ieee802154Address::Nwk(Nwk(0xffff))),
                 src_pan_id: None,
                 src_address: None,
-                payload: b"\x07\x00\x09".to_vec(),
-                fcs: 12972,
-            },
-            channel: 20,
+                payload: b"\x07".to_vec(),
+                fcs: 0x0000, // It'll be recalculated
+            }
+            .to_bytes(),
+            channel: channel,
             max_csma_backoffs: 1,
             max_frame_retries: 4,
             enable_csma_ca: true,
@@ -76,9 +108,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             is_security_processed: true,
             tx_delay: 0 as u32,
             tx_delay_base_time: 0 as u32,
-            rx_channel_after_tx: 20,
+            rx_channel_after_tx: channel,
             tx_power: 8,
         };
+
+        sequence = (sequence + 1) % 255;
 
         match client.transmit_frame(&frame).await {
             Ok(status) => println!("Frame transmitted: {:?}", status),

--- a/zigpy_spinel/spinel.py
+++ b/zigpy_spinel/spinel.py
@@ -265,5 +265,5 @@ class SpinelProtocol(SerialProtocol):
             return
 
         await self.wait_for_property(
-            PropertyID.LAST_STATUS, Status.RESET_SOFTWARE.serialize()
+            PropertyID.LAST_STATUS, Status.RESET_POWER_ON.serialize()
         )

--- a/zigpy_spinel/tools/beacon_test.py
+++ b/zigpy_spinel/tools/beacon_test.py
@@ -1,0 +1,91 @@
+import asyncio
+import time
+import random
+import sys
+import zigpy.types
+import zigpy.types as t
+
+from ..common import connect_protocol
+from ..spinel import SpinelProtocol
+from ..spinel_types import PropertyID
+from .. import zigbee_types as zigbee
+
+
+async def main():
+    channels = list(map(int, sys.argv[2].split(",")))
+    current_channel = random.choice(channels)
+
+    async with connect_protocol(sys.argv[1], 460800, SpinelProtocol) as spinel:
+        await spinel.probe()
+        await spinel.reset()
+
+        await spinel.set_property(PropertyID.PHY_ENABLED, zigpy.types.uint8_t(1))
+        await spinel.set_property(
+            PropertyID.MAC_RAW_STREAM_ENABLED, zigpy.types.Bool.true
+        )
+        await spinel.set_property(
+            PropertyID.PHY_CHAN, zigpy.types.uint8_t(current_channel)
+        )
+
+        last_time = time.time()
+        seq = 0
+
+        while True:
+            next_time = time.time()
+            print(f"=== Delta: {next_time - last_time:0.8f}")
+            last_time = next_time
+
+            seq = (seq + 1) % 0xFF
+            frame = zigbee.IEEE802154Frame(
+                frame_control=zigbee.IEEE802154FrameControl(
+                    frame_type=zigbee.IEEE802154FrameType.Command,
+                    security_enabled=False,
+                    frame_pending=False,
+                    ack_request=False,
+                    pan_id_compression=False,
+                    reserved=0b0,
+                    sequence_number_suppression=False,
+                    information_elements_present=False,
+                    dest_addr_mode=zigbee.IEEE802154AddressingMode.Short,
+                    frame_version=0b00,
+                    src_addr_mode=zigbee.IEEE802154AddressingMode.None_,
+                ),
+                sequence_number=t.uint8_t(seq),
+                dest_pan_id=t.uint16_t(0xFFFF),
+                dest_address=t.uint16_t(0xFFFF),
+                src_pan_id=None,
+                src_address=None,
+                payload=zigbee.IEEE802154CommandId.BeaconRequest.serialize(),
+                fcs=None,
+            )
+
+            data = frame.serialize()
+
+            await spinel.set_property(
+                PropertyID.STREAM_RAW,
+                (
+                    t.uint16_t(len(data)).serialize()
+                    + data
+                    + t.uint8_t(current_channel).serialize()
+                    + t.uint8_t(1).serialize()  # CCA backoff attempts
+                    + t.uint8_t(4).serialize()  # CCA retries
+                    + t.Bool.false.serialize()  # enable CSMA-CA
+                    + t.Bool.true.serialize()  # mIsHeaderUpdated
+                    + t.Bool.false.serialize()  # mIsARetx
+                    + t.Bool.true.serialize()  # mIsSecurityProcessed
+                    + t.uint8_t(0).serialize()  # mTxDelay
+                    + t.uint8_t(0).serialize()  # mTxDelayBaseTime
+                    + t.uint8_t(current_channel).serialize()  # RX channel after TX done
+                ),
+            )
+
+        await asyncio.sleep(900)
+
+
+if __name__ == "__main__":
+    import logging
+    import coloredlogs
+
+    coloredlogs.install(level=logging.DEBUG)
+
+    asyncio.run(main())

--- a/zigpy_spinel/zigbee_types.py
+++ b/zigpy_spinel/zigbee_types.py
@@ -163,7 +163,11 @@ class IEEE802154Frame:
                 IEEE802154FrameType.Command,
             )
         ):
-            data += self.src_pan_id.serialize()
+            if not (
+                self.frame_control.frame_type == IEEE802154FrameType.Command
+                and self.payload == b"\x07"
+            ):
+                data += self.src_pan_id.serialize()
 
         if self.frame_control.src_addr_mode == IEEE802154AddressingMode.Short:
             data += self.src_address.serialize()


### PR DESCRIPTION
This PR implements a Spinel client that performs IO on a serial port and includes convenience wrappers for common functionality (i.e. property getters, setters, and change notifications).

An example utility implementing a packet capture tool is used as the base, as the Zigbee stack will use the exact same property interface.